### PR TITLE
Created DELETE endpoint for Articles table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.Articles;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.ArticlesRepository;
 
@@ -73,4 +72,16 @@ public class ArticlesController extends ApiController{
         return savedArticles;
     }
     
+    @Operation(summary= "Delete an Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticles(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles article = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        articlesRepository.delete(article);
+        return genericMessage("Article with id %s deleted".formatted(id));
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -1,0 +1,76 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "Articles")
+@RequestMapping("/api/articles")
+@RestController
+@Slf4j
+public class ArticlesController extends ApiController{
+    
+    @Autowired
+    ArticlesRepository articlesRepository;
+
+    @Operation(summary= "List all articles")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<Articles> allArticles() {
+        Iterable<Articles> articles = articlesRepository.findAll();
+        return articles;
+    }
+
+    @Operation(summary= "Create a new article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Articles postArticles(
+            @Parameter(name="title") @RequestParam String title,
+            @Parameter(name="url") @RequestParam String url,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="email") @RequestParam String email,
+            @Parameter(name="dateAdded", description="(in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateAdded") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateAdded)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("localDateTime={}", dateAdded);
+
+        Articles articles = new Articles();
+        articles.setTitle(title);
+        articles.setUrl(url);
+        articles.setExplanation(explanation);
+        articles.setEmail(email);
+        articles.setDateAdded(dateAdded);
+        
+        Articles savedArticles = articlesRepository.save(articles);
+
+        return savedArticles;
+    }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Articles.java
@@ -1,0 +1,30 @@
+package edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "articles")
+public class Articles {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String title;
+  private String url;
+  private String explanation;
+  private String email;
+  private LocalDateTime dateAdded;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/ArticlesRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Articles;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ArticlesRepository extends CrudRepository<Articles, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "Articles-1",
+          "author": "ANIMESH_S",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "ARTICLES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "CONSTRAINT_3"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TITLE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "URL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_ADDED",
+                      "type": "TIMESTAMP"
+                    }
+                  }
+                ],
+                "tableName": "ARTICLES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/main/resources/db/migration/changes/Articles.json
+++ b/src/main/resources/db/migration/changes/Articles.json
@@ -3,7 +3,7 @@
       {
         "changeSet": {
           "id": "Articles-1",
-          "author": "ANIMESH_S",
+          "author": "AnimeshS",
           "preConditions": [
             {
               "onFail": "MARK_RAN"

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -1,0 +1,147 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.Articles;
+import edu.ucsb.cs156.example.repositories.ArticlesRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = ArticlesController.class)
+@Import(TestConfig.class)
+public class ArticlesControllerTests extends ControllerTestCase {
+
+        @MockBean
+        ArticlesRepository articlesRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/articles/all
+        
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_articles() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("TestArticle1")
+                                .url("TestArticle1.com")
+                                .explanation("The first test article")
+                                .email("TestArticle1@gmail.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                Articles articles2 = Articles.builder()
+                                .title("TestArticle2")
+                                .url("TestArticle2.com")
+                                .explanation("The second test article")
+                                .email("TestArticle2@gmail.com")
+                                .dateAdded(ldt2)
+                                .build();
+
+                ArrayList<Articles> expectedDates = new ArrayList<>();
+                expectedDates.addAll(Arrays.asList(articles1, articles2));
+
+                when(articlesRepository.findAll()).thenReturn(expectedDates);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/articles/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(articlesRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedDates);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        // Tests for POST /api/articles/post...
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/articles/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/articles/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_article() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles articles1 = Articles.builder()
+                                .title("TestArticle1")
+                                .url("TestArticle1.com")
+                                .explanation("Test1")
+                                .email("TestArticle1@gmail.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.save(eq(articles1))).thenReturn(articles1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/articles/post?title=TestArticle1&url=TestArticle1.com&explanation=Test1&email=TestArticle1@gmail.com&dateAdded=2022-01-03T00:00:00")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).save(articles1);
+                String expectedJson = mapper.writeValueAsString(articles1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -144,4 +144,57 @@ public class ArticlesControllerTests extends ControllerTestCase {
                 assertEquals(expectedJson, responseString);
         }
 
+        // Tests for DELETE /api/ucsbdates?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_article() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                Articles article = Articles.builder()
+                                .title("TestArticle1")
+                                .url("TestArticle1.com")
+                                .explanation("Test1")
+                                .email("TestArticle1@gmail.com")
+                                .dateAdded(ldt1)
+                                .build();
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(article));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                verify(articlesRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Article with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/articles?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(articlesRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("Articles with id 15 not found", json.get("message"));
+        }
+
 }


### PR DESCRIPTION
In this PR, we edit ArticlesController to handle DELETE endpoint for a specific record in Articles table. ArticlesControllerTests successfully passes tests with 100% coverage.

Closes #42 